### PR TITLE
fix a leak of platform information via navigator.appVersion.

### DIFF
--- a/src/js/client.js
+++ b/src/js/client.js
@@ -1,11 +1,11 @@
 const templatePart1 = 'Object.defineProperty(navigator,"userAgent",{get:function(){return"'
-const templatePart2 = '"}}),Object.defineProperty(navigator,"vendor",{get:function(){return""}}),Object.defineProperty(navigator,"platform",{get:function(){return""}});'
-
+const templatePart2 = '"}}),Object.defineProperty(navigator, "appVersion", {get: function() {return "'
+const templatePart3 = '"}}), Object.defineProperty(navigator,"vendor",{get:function(){return""}}),Object.defineProperty(navigator,"platform",{get:function(){return""}});'
 chrome.storage.local.get(null, state => {
   if (state.enabled) {
     const ua = state.custom ? state.customUA : state.browsers[state.browser][state.os].ua
     const script = document.createElement('script')
-    script.innerText = templatePart1 + ua + templatePart2
+    script.innerText = templatePart1 + ua + templatePart2 + ua + templatePart3
     document.head.appendChild(script)
   }
 })


### PR DESCRIPTION
The `navigator.appVersion` property returns a string that can
identify a user's browser and platform. It is documented [on mdn](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorID/appVersion).

I noticed on the Brave browser running on Linux, it looked to be
a copy of the User-Agent string. I decided to update client.js
to return the UA string from `navigator.appVersion` - same as
we are doing for `navigator.userAgent`.

I found [this site](https://chrispederick.com/work/user-agent-switcher/features/test/) useful for testing the leak.

I took a screenshot of `navigator.appVersion` leaking my browser and platform (Chrome/Linux):

![image](https://user-images.githubusercontent.com/8934693/100493899-3d3ae200-313c-11eb-8f87-70d92fec94e7.png)

This is how it looks after the fix:

![image](https://user-images.githubusercontent.com/8934693/100493909-53e13900-313c-11eb-85e7-696b158e77ea.png)
